### PR TITLE
Add dimensions option to print the image's width and height

### DIFF
--- a/lib/spriteful/cli.rb
+++ b/lib/spriteful/cli.rb
@@ -18,6 +18,7 @@ module Spriteful
     class_option :horizontal, type: :boolean, desc: 'Change the sprite orientation to "horizontal".'
     class_option :save, type: :boolean, desc: 'Save the supplied arguments to ".spritefulrc".'
     class_option :spacing, type: :numeric, desc: 'Add spacing between the images in the sprite.'
+    class_option :dimensions, type: :boolean, desc: 'Include additional Placeholder Selectors/Mixins with the image\'s dimensions.'
 
     class_option :version, type: :boolean, aliases: '-v'
     class_option :optimize, type: :boolean, default: true, desc: 'Optimizes the combined PNG and inline SVG images.'
@@ -104,7 +105,8 @@ module Spriteful
         root: options.root,
         format: options.format,
         rails: options.rails?,
-        mixin: options.mixin?
+        mixin: options.mixin?,
+        dimensions: options.dimensions?
       }
     end
 

--- a/lib/spriteful/stylesheet.rb
+++ b/lib/spriteful/stylesheet.rb
@@ -33,6 +33,7 @@ module Spriteful
       @format = options[:format]
       @mixin = options.fetch(:mixin, false)
       @rails = options.fetch(:rails, false)
+      @dimensions = options.fetch(:dimensions, false)
 
       @path = @destination.join(name)
     end
@@ -66,6 +67,11 @@ module Spriteful
     # Internal: returns the 'mixin' flag.
     def mixin?
       @mixin
+    end
+
+    # Internal: returns the 'dimensions' flag.
+    def dimensions?
+      @dimensions
     end
 
     # Internal: select the extension prefix for the SCSS selector.

--- a/lib/spriteful/stylesheets/template.scss.erb
+++ b/lib/spriteful/stylesheets/template.scss.erb
@@ -16,6 +16,21 @@
 //   <%= extension_strategy %><%= class_name_for(sprite) %>-sprite-<%= class_name_for(sprite.images.first) %>;
 //   // Your styles here.
 // }
+<%- if dimensions? -%>
+//
+// You can also include an image's dimensions anywhere:
+//
+// .my-thing-wrapper {
+//   <%= extension_strategy %><%= class_name_for(sprite) %>-sprite-<%= class_name_for(sprite.images.first) %>-dimensions;
+// }
+//
+// or include the dimensions with the sprite itself:
+//
+// .my-thing {
+//   <%= extension_strategy %><%= class_name_for(sprite) %>-sprite-<%= class_name_for(sprite.images.first) %>-dimensioned;
+//   // Your styles here.
+// }
+<%- end -%>
 //
 // There also will be available a variable named '$<%= class_name_for(sprite) %>-sprite-names'
 // with all the images inside this sprite.
@@ -39,6 +54,16 @@
   }
   <%- end -%>
 }
+<%- if dimensions? -%>
+<%= extension_prefix %><%= class_name_for(sprite) %>-sprite-<%= class_name_for(image) %>-dimensions {
+  width: <%= image.width %>px;
+  height: <%= image.height %>px;
+}
+<%= extension_prefix %><%= class_name_for(sprite) %>-sprite-<%= class_name_for(image) %>-dimensioned {
+  <%= extension_strategy %><%= class_name_for(sprite) %>-sprite-<%= class_name_for(image) %>;
+  <%= extension_strategy %><%= class_name_for(sprite) %>-sprite-<%= class_name_for(image) %>-dimensions;
+}
+<%- end -%>
 <% end %>
 
 $<%= class_name_for(sprite) %>-sprite-names: <%= sprite.images.map { |i| class_name_for(i) }.join(' ') %>;

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -71,5 +71,47 @@ describe Spriteful::Stylesheet do
         expect(output).to match(/^  .svg & \{/)
       end
     end
+
+    describe 'dimensions' do
+      it 'renders the placeholder selectors with dimensions' do
+        sprite = Spriteful::Sprite.new(source, destination)
+        stylesheet = Spriteful::Stylesheet.new(sprite, destination, format: 'scss', dimensions: true)
+        output = stylesheet.render
+
+        expect(output).to match(/%simple-sprite-blue-dimensions \{/)
+        expect(output).to match(/%simple-sprite-red-dimensions \{/)
+      end
+
+      it 'renders the mixins with dimensions' do
+        sprite = Spriteful::Sprite.new(source, destination)
+        stylesheet = Spriteful::Stylesheet.new(sprite, destination, format: 'scss', mixin: true, dimensions: true)
+        output = stylesheet.render
+
+        expect(output).to match(/@mixin simple-sprite-blue-dimensions \{/)
+        expect(output).to match(/@mixin simple-sprite-red-dimensions \{/)
+      end
+
+      it 'renders the placeholder selectors with dimensioned sprites' do
+        sprite = Spriteful::Sprite.new(source, destination)
+        stylesheet = Spriteful::Stylesheet.new(sprite, destination, format: 'scss', dimensions: true)
+        output = stylesheet.render
+
+        expect(output).to match(/%simple-sprite-blue-dimensioned \{/)
+        expect(output).to match(/%simple-sprite-red-dimensioned \{/)
+        expect(output).to match(/@extend %simple-sprite-blue-dimensions;/)
+        expect(output).to match(/@extend %simple-sprite-red-dimensions;/)
+      end
+
+      it 'renders the mixins with dimensioned sprites' do
+        sprite = Spriteful::Sprite.new(source, destination)
+        stylesheet = Spriteful::Stylesheet.new(sprite, destination, format: 'scss', mixin: true, dimensions: true)
+        output = stylesheet.render
+
+        expect(output).to match(/@mixin simple-sprite-blue-dimensioned \{/)
+        expect(output).to match(/@mixin simple-sprite-red-dimensioned \{/)
+        expect(output).to match(/@include simple-sprite-blue-dimensions;/)
+        expect(output).to match(/@include simple-sprite-red-dimensions;/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #16.

I didn't add dimensions to the vanilla CSS, as I'm not sure what the ideal selector name would be, or even if we should generate those extra dimension classes.
