### PR TITLE
Allow to specify the name of the sprite

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ If you are using SVG images, the embedded SVG as data URI will be optimized with
 
 * `--stylesheets` (`-s`) - Directory to save the generated stylesheet(s), instead of copying them to the clipboard.
 * `--destination` (`-d`) - Directory to save the generated image(s).
+* `--name` (`-n`) - Name of generated sprite.
 * `--rails` (`-r`) - Forces rails specific settings, see [Spriteful and Rails](#spriteful-and-rails) for more info.
 * `--format` (`-f`) - Format to generate the sprite(s) stylesheet(s). Either "css" or "scss".
 * `--template` (`-t`) - The path for a custom Stylesheet template.

--- a/lib/spriteful/cli.rb
+++ b/lib/spriteful/cli.rb
@@ -12,6 +12,7 @@ module Spriteful
     class_option :format, aliases: '-f', banner: 'FORMAT', type: :string, desc: 'Format to generate the sprite(s) stylesheet(s). Either "css" or "scss".', default: 'css'
     class_option :stylesheets, aliases: '-s', banner: 'STYLESHEETS_DIR', type: :string, desc: 'Directory to save the generated stylesheet(s), instead of copying them to the clipboard.', default: Dir.pwd
     class_option :destination, aliases: '-d', banner: 'DESTINATION_DIR', type: :string, desc: 'Destination directory to save the combined image(s).', default: Dir.pwd
+    class_option :name, aliases: '-n', banner: 'SPRITE_NAME', type: :string, desc: 'Name of generated sprite.'
     class_option :root, aliases: '-r', banner: 'ROOT_DIR', type: :string, desc: 'Root folder from where your static files will be served.'
     class_option :template, aliases: '-t', banner: 'TEMPLATE', type: :string, desc: 'Custom template file in ERB format to be used instead of the default.'
 
@@ -135,7 +136,8 @@ module Spriteful
       {
         horizontal: options.horizontal?,
         spacing: options.spacing,
-        optimize: options.optimize
+        optimize: options.optimize,
+        name: options.name
       }
     end
 

--- a/lib/spriteful/sprite.rb
+++ b/lib/spriteful/sprite.rb
@@ -51,7 +51,7 @@ module Spriteful
       @spacing     = options[:spacing] || 0
       @optimize    = options[:optimize]
 
-      @name     = File.basename(source_dir)
+      @name     = options[:name] || File.basename(source_dir)
       @filename = "#{name}.png"
       @path     = File.expand_path(File.join(destination, @filename))
       @list     = Magick::ImageList.new(*sources) { self.background_color = 'none' }

--- a/spec/sprite_spec.rb
+++ b/spec/sprite_spec.rb
@@ -52,6 +52,11 @@ describe Spriteful::Sprite do
       sprite = Spriteful::Sprite.new(source, destination)
       expect(sprite.filename).to eq('simple.png')
     end
+
+    it 'returns the name option if it is present' do
+      sprite = Spriteful::Sprite.new(source, destination, name: 'foo')
+      expect(sprite.filename).to eq('foo.png')
+    end
   end
 
   describe '#combine!' do

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -16,6 +16,16 @@ describe Spriteful::Stylesheet do
       expect(output).to match(/.simple.red \{/)
     end
 
+    it 'uses the custom name of the sprite' do
+      sprite = Spriteful::Sprite.new(source, destination, name: 'foo')
+      stylesheet = Spriteful::Stylesheet.new(sprite, destination, format: 'css')
+      output = stylesheet.render
+
+      expect(output).to match(/.foo \{/)
+      expect(output).to match(/.foo.blue \{/)
+      expect(output).to match(/.foo.red \{/)
+    end
+
     it 'renders the SCSS format' do
       sprite = Spriteful::Sprite.new(source, destination)
       stylesheet = Spriteful::Stylesheet.new(sprite, destination, format: 'scss')
@@ -24,6 +34,16 @@ describe Spriteful::Stylesheet do
       expect(output).to match(/%simple-sprite \{/)
       expect(output).to match(/%simple-sprite-blue \{/)
       expect(output).to match(/%simple-sprite-red \{/)
+    end
+
+    it 'uses the custom name of the sprite for SCSS format' do
+      sprite = Spriteful::Sprite.new(source, destination, name: 'foo')
+      stylesheet = Spriteful::Stylesheet.new(sprite, destination, format: 'scss')
+      output = stylesheet.render
+
+      expect(output).to match(/%foo-sprite \{/)
+      expect(output).to match(/%foo-sprite-blue \{/)
+      expect(output).to match(/%foo-sprite-red \{/)
     end
 
     it 'renders the SCSS format using mixin' do


### PR DESCRIPTION
Right now the name of the sprite is the basename of the source folder.
If you have a directory structrure like:

`home/sprite` your sprite file will be called `sprites/sprite.png`. For this case is better if the sprite would be called `sprites/home.png`.
This new option make this possible.
