### PR TITLE
Change Rails defaults to use `app/assets/sprites`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,19 @@ spriteful images/icons images/flags -s stylesheets -d images
 ### Spriteful and Rails
 
 If you are working on a Ruby on Rails application Spriteful can provide some extra goodies for
-you. If run you the `spriteful` command with the `--rails` flag, all sprites under `app/assets/images/sprites`
-will be generated with respective stylesheets at `app/assets/stylesheets/sprites`, using the proper `image_url`
+you. If run you the `spriteful` command with the `--rails` flag, all sprites under `app/assets/sprites`
+will be generated with respective stylesheets at `app/assets/sprites`, using the proper `image_url`
 helper for the format of your choice.
 
-So, given that you have the `icons` and `flags` directories with your images under `app/assets/images/sprites`,
+So, given that you have the `icons` and `flags` directories with your images under `app/assets/sprites`,
 you might get a similar output when generating these two sprites.
 
 ```bash
 spriteful --rails
-# create  app/assets/images/sprites/flags.png
-# create  app/assets/stylesheets/sprites/flags.css.erb
-# create  app/assets/images/sprites/icons.png
-# create  app/assets/stylesheets/sprites/icons.css.erb
+# create  app/assets/sprites/flags.png
+# create  app/assets/sprites/flags.css.erb
+# create  app/assets/sprites/icons.png
+# create  app/assets/sprites/icons.css.erb
 ```
 
 ## Naming conventions

--- a/lib/spriteful/cli.rb
+++ b/lib/spriteful/cli.rb
@@ -162,15 +162,28 @@ module Spriteful
     #
     # Returns an Array of directories.
     def detect_sources
-      Dir['app/assets/images/sprites/*'].select { |dir| File.directory?(dir) }
+      deprecated = Dir['app/assets/images/sprites/*'].select { |dir| File.directory?(dir) }
+
+      if deprecated.any?
+        deprecate "Deprecated sources found: #{deprecated.map { |path| "'#{path}'" }.join(', ')}.\nMove them to 'app/assets/sprites'."
+      end
+
+      deprecated + Dir['app/assets/sprites/*'].select { |dir| File.directory?(dir) }
     end
 
     # Internal: Sets Rails specific default options to the 'options' object.
     #
     # Returns nothing.
     def set_rails_defaults
-      options['stylesheets'] = File.expand_path('app/assets/stylesheets/sprites')
-      options['destination'] = File.expand_path('app/assets/images/sprites')
+      deprecated_stylesheets = 'app/assets/stylesheets/sprites'
+      deprecated_destination = 'app/assets/images/sprites'
+
+      if File.directory?(deprecated_destination) || File.directory?(deprecated_destination)
+        deprecate "Sprites were previously saved at '#{deprecated_stylesheets}' and '#{deprecated_destination}'. They are now at 'app/assets/sprites' instead."
+      end
+
+      options['stylesheets'] = File.expand_path('app/assets/sprites')
+      options['destination'] = File.expand_path('app/assets/sprites')
     end
 
     # Internal: Checks if we should save the supplied user arguments into
@@ -179,6 +192,10 @@ module Spriteful
     # Returns true or false.
     def save_options?
       @save_options
+    end
+
+    def deprecate(message)
+      say_status :deprecated, message, :red
     end
   end
 end


### PR DESCRIPTION
Partial support for the #28 proposal.

The feedback goes something like this. We still pick sources from `app/assets/images`, and always save the final files on `app/assets/sprites`.

```
$ bin/spriteful --rails
  deprecated  Deprecated sources found: 'app/assets/images/sprites/simple'.
Move them to 'app/assets/sprites'.
  deprecated  Sprites were previously saved at 'app/assets/stylesheets/sprites' and 'app/assets/images/sprites'. They are now at 'app/assets/sprites' instead.
  optimizing  No optimizer found. Please install at least one of the following: pngcrush, pngout, advpng, optipng, pngquant.
   identical  app/assets/sprites/simple.png
   identical  app/assets/sprites/simple.css.erb
```
